### PR TITLE
Add tini unshare

### DIFF
--- a/src/tini.c
+++ b/src/tini.c
@@ -26,6 +26,10 @@
 #include "tiniConfig.h"
 #include "tiniLicense.h"
 
+#ifndef CLONE_NEWCGROUP
+#define CLONE_NEWCGROUP		0x02000000	/* New cgroup namespace */
+#endif
+
 #define S_IWUGO		(S_IWUSR|S_IWGRP|S_IWOTH)
 #define S_IRUGO		(S_IRUSR|S_IRGRP|S_IROTH)
 #define REDIRECT_STDERR	"TITUS_REDIRECT_STDERR"


### PR DESCRIPTION
This makes it so that the Tini binary can call unshare for cgroups specifically. The purpose of this is to allow for post-runc unsharing AFTER the fork, versus before the work.