### PR TITLE
Go back to only sending a single notify fd instead of 3

### DIFF
--- a/src/seccomp_fd_notify.c
+++ b/src/seccomp_fd_notify.c
@@ -6,12 +6,9 @@
 
 #include <linux/audit.h>
 #include <linux/seccomp.h>
-#include <linux/limits.h>
 #include <linux/filter.h>
-#include <sys/stat.h>
 #include <sys/syscall.h>
 #include <stddef.h>
-#include <fcntl.h>
 
 #include <sys/socket.h>
 #include <sys/un.h>
@@ -22,34 +19,25 @@
 #define PRINT_WARNING(...)  { fprintf(stderr, __VA_ARGS__); fprintf(stderr, "\n"); }
 #define PRINT_INFO(...)  { fprintf(stderr, __VA_ARGS__); fprintf(stderr, "\n"); }
 
-static int send_fds(int sock, int *fds_to_send, int num_fds)
+static int send_fd(int sock, int fd)
 {
 	struct msghdr msg = {0};
-	struct cmsghdr *cmsg = NULL;
-	memset(&msg, 0, sizeof(msg));
+	struct cmsghdr *cmsg;
+	char buf[CMSG_SPACE(sizeof(int))] = {0}, c = 'c';
+	struct iovec io = {
+		.iov_base = &c,
+		.iov_len = 1,
+	};
 
-	size_t cmsgbufsize = CMSG_SPACE(num_fds * sizeof(int));
-	char *cmsgbuf = NULL;
-	cmsgbuf = malloc(cmsgbufsize);
-
-	struct iovec iov;
-	char buf[1] = {0};
-	memset(&iov, 0, sizeof(iov));
-	iov.iov_base = buf;
-	iov.iov_len = sizeof(buf);
-
-	msg.msg_iov = &iov;
+	msg.msg_iov = &io;
 	msg.msg_iovlen = 1;
-	msg.msg_control = cmsgbuf;
-	msg.msg_controllen = cmsgbufsize;
-
+	msg.msg_control = buf;
+	msg.msg_controllen = sizeof(buf);
 	cmsg = CMSG_FIRSTHDR(&msg);
 	cmsg->cmsg_level = SOL_SOCKET;
 	cmsg->cmsg_type = SCM_RIGHTS;
-	cmsg->cmsg_len = CMSG_LEN(num_fds * sizeof(int));
-
-	memcpy(CMSG_DATA(cmsg), fds_to_send, num_fds * sizeof(int));
-
+	cmsg->cmsg_len = CMSG_LEN(sizeof(int));
+	*((int *)CMSG_DATA(cmsg)) = fd;
 	msg.msg_controllen = cmsg->cmsg_len;
 
 	int sendmsg_return = sendmsg(sock, &msg, 0);
@@ -115,20 +103,6 @@ static int install_notify_filter(void) {
 	return notify_fd;
 }
 
-int get_mem_fd(int pid) {
-	char mem_path[PATH_MAX];
-	snprintf(mem_path, sizeof(mem_path), "/proc/%d/mem", pid);
-	int mem_fd = open(mem_path, O_RDWR | O_CLOEXEC);
-	return mem_fd;
-}
-
-int get_pid_fd(int pid) {
-	char pid_path[PATH_MAX];
-	snprintf(pid_path, sizeof(pid_path), "/proc/%d", pid);
-	int pid_fd = open(pid_path, O_RDONLY | O_DIRECTORY | O_CLOEXEC);
-	return pid_fd;
-}
-
 void maybe_setup_seccomp_notifer() {
 	char *socket_path;
 	socket_path = getenv(TITUS_SECCOMP_NOTIFY_SOCK_PATH);
@@ -154,20 +128,13 @@ void maybe_setup_seccomp_notifer() {
 			return;
 		}
 
-		int pid = getpid();
-		int notify_fd, pid_fd, mem_fd = -1;
+		int notify_fd = -1;
 		notify_fd = install_notify_filter();
-		pid_fd = get_pid_fd(pid);
-		mem_fd = get_mem_fd(pid);
-
-		int send_fd_list[3];
-		send_fd_list[0] = pid_fd;
-		send_fd_list[1] = mem_fd;
-		send_fd_list[2] = notify_fd;
-
-		if (send_fds(sock_fd, send_fd_list, 3) == -1) {
-			PRINT_WARNING("Couldn't send fds to the socket at %s: %s", socket_path, strerror(errno));
+		if (send_fd(sock_fd, notify_fd) == -1) {
+			PRINT_WARNING("Couldn't send fd to the socket at %s: %s", socket_path, strerror(errno));
 			return;
+		} else {
+			PRINT_INFO("Sent the notify fd to the seccomp agent socket at %s", socket_path)
 		}
 	}
 	return;


### PR DESCRIPTION
Revert "Send mem and pid fds as well as notify fds"

This reverts commit 38857c8f738998ef4183dcab7f7e97546d52b299.

----

It ended up that this was a premature optimization, and the agent has to get the memfd and procfd of the *real* process itself on its own anyway.

cc @keerti